### PR TITLE
feat: Add Sphinx documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,32 @@ python demos/em/01_validation_demo.py
 pytest
 ```
 
+## Building the Documentation
+
+This project uses Sphinx to generate API documentation from the source code.
+
+### Prerequisites
+
+First, install the documentation-specific dependencies:
+
+```bash
+pip install -r docs/requirements.txt
+```
+
+### Build Script
+
+A helper script is provided to simplify the build process. To build the documentation, run the following command from the project root:
+
+```bash
+./docs/build_docs.sh
+```
+
+The script will clean the previous build and generate the HTML documentation in the `docs/_build/html` directory.
+
+### Viewing the Documentation
+
+To view the documentation, open the `docs/_build/html/index.html` file in your web browser.
+
 ## Example: Calculate and Plot Magnetic Field of a Dipole
 ```python
 from src.em_app.sources import Dipole

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/build_docs.sh
+++ b/docs/build_docs.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# A script to automate the Sphinx documentation build process.
+
+# Clean the previous build
+make -C /app/docs clean
+
+# Build the HTML documentation
+make -C /app/docs html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,39 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+import os
+import sys
+sys.path.insert(0, os.path.abspath('../src'))
+
+project = 'em-simulation-platform'
+copyright = '2025, Shashi Manikonda'
+author = 'Shashi Manikonda'
+
+version = '0.1'
+release = '0.1'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon',
+    'sphinx.ext.viewcode',
+    'sphinx_rtd_theme',
+]
+
+templates_path = ['_templates']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'sphinx_rtd_theme'
+html_static_path = ['_static']

--- a/docs/em_app.rst
+++ b/docs/em_app.rst
@@ -1,0 +1,37 @@
+em\_app package
+===============
+
+Submodules
+----------
+
+em\_app.plotting module
+-----------------------
+
+.. automodule:: em_app.plotting
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+em\_app.solvers module
+----------------------
+
+.. automodule:: em_app.solvers
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+em\_app.sources module
+----------------------
+
+.. automodule:: em_app.sources
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+em\_app.vector\_fields module
+-----------------------------
+
+.. automodule:: em_app.vector_fields
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,15 @@
+Welcome to the em-simulation-platform documentation!
+====================================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   modules
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -1,0 +1,7 @@
+em_app
+======
+
+.. toctree::
+   :maxdepth: 4
+
+   em_app

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+sphinx
+sphinx_rtd_theme

--- a/src/em_app/vector_fields.py
+++ b/src/em_app/vector_fields.py
@@ -1,16 +1,9 @@
 """
-magneticfield: A library for magnetic field calculations and visualization.
+Vector and Vector Field representations.
 
-This module defines classes and functions for working with magnetic fields,
-with a focus on using Multivariate Taylor Functions (MTFs) from the mtflib
-library.
-
-The core components are:
-- Bvec: A representation of a magnetic field vector at a single point,
-        using MTFs for each component.
-- Bfield: A container class for a collection of Bvec objects, providing
-          methods for analysis and visualization, such as plotting the field
-          on a plane or in 3D.
+This module provides classes for representing 3D vectors and vector fields,
+with support for numerical data and `mtflib` Multivariate Taylor Functions (MTFs).
+It includes classes like Vector, FieldVector, VectorField, and VectorFieldGrid.
 """
 
 import numpy as np
@@ -755,7 +748,7 @@ class VectorFieldGrid(VectorField):
 
         Returns:
             np.ndarray: The field points as a grid. The shape will be
-                        (*grid_shape, 3).
+                        ``(*grid_shape, 3)``.
         """
         numerical_points, _ = self._get_numerical_data()
         return numerical_points.reshape(*self.grid_shape, 3)
@@ -766,7 +759,7 @@ class VectorFieldGrid(VectorField):
 
         Returns:
             np.ndarray: The B-field vectors as a grid. The shape will be
-                        (*grid_shape, 3).
+                        ``(*grid_shape, 3)``.
         """
         _, numerical_vectors = self._get_numerical_data()
         return numerical_vectors.reshape(*self.grid_shape, 3)


### PR DESCRIPTION
This commit adds a complete Sphinx documentation setup to the project.

It includes:
- A `docs/` directory with all necessary Sphinx configuration files.
- `sphinx-apidoc` integration to generate API documentation from the `src/em_app` module.
- A `build_docs.sh` script to automate the build process.
- Updated docstrings in `src/em_app/vector_fields.py` to fix formatting issues.
- A new "Building the Documentation" section in the main `README.md` file.