### PR TITLE
🧪 test: add test for unknown backend in calculate_b_field

### DIFF
--- a/src/em_app/solvers.py
+++ b/src/em_app/solvers.py
@@ -80,7 +80,7 @@ def calculate_b_field(coil_instance, field_points, backend=Backend.PYTHON):
             field_points=field_points,
             backend=Backend.COSY,
         )
-    else:
+    elif backend in (Backend.PYTHON, Backend.COSY):
         bx, by, bz = serial_biot_savart(
             element_centers=element_centers_np,
             element_lengths=coil_instance.segment_lengths,
@@ -88,6 +88,8 @@ def calculate_b_field(coil_instance, field_points, backend=Backend.PYTHON):
             field_points=field_points,
             backend=backend,
         )
+    else:
+        raise ValueError(f"Unknown backend: {backend}")
 
     # Optimized Vector Field Creation (SoA enforced)
     if coil_instance.use_mtf_for_segments:

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -164,3 +164,23 @@ def test_biot_savart_with_mtf(backend):
     y_component = b_vectors_mtf[0].y
     y_coeff = y_component.extract_coefficient(tuple([0] * y_component.dimension))
     assert np.isclose(y_coeff.item(), 0)
+
+def test_calculate_b_field_unknown_backend():
+    """
+    Test that calculate_b_field raises a ValueError when an unknown backend
+    is passed (bypassing the string conversion logic).
+    """
+    radius = 1.0
+    current = 1.0
+    num_segments = 4
+    center = np.array([0, 0, 0])
+    axis = np.array([0, 0, 1])
+
+    ring_coil = RingCoil(current, radius, num_segments, center, axis)
+    field_points = np.array([[0, 0, 0]])
+
+    class UnknownBackend:
+        pass
+
+    with pytest.raises(ValueError, match="Unknown backend"):
+        calculate_b_field(ring_coil, field_points, backend=UnknownBackend())


### PR DESCRIPTION
🎯 **What:** Added a missing error test for unknown backend in `calculate_b_field` and fixed the dispatching logic to explicitly handle unknown backends.
📊 **Coverage:** The test covers the scenario where an invalid backend object bypasses the string-to-enum conversion and properly hits the `else` block during backend dispatch, asserting that a `ValueError` is raised.
✨ **Result:** Improved test coverage and more robust handling of invalid backend values.

---
*PR created automatically by Jules for task [8754404170136732925](https://jules.google.com/task/8754404170136732925) started by @shashi-manikonda*